### PR TITLE
add missing route-is helper

### DIFF
--- a/addon/helpers/route-is.js
+++ b/addon/helpers/route-is.js
@@ -1,0 +1,14 @@
+/* eslint-disable ember/no-observers */
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { observer } from '@ember/object';
+
+export default Helper.extend({
+  router: service(),
+  onNewRoute: observer('router.currentRouteName', function() {
+    this.recompute();
+  }),
+  compute([route]) {
+    return route === this.router.currentRouteName;
+  },
+});

--- a/app/helpers/route-is.js
+++ b/app/helpers/route-is.js
@@ -1,0 +1,1 @@
+export { default, routeIs } from 'empress-blog-ghost-helpers/helpers/route-is';


### PR DESCRIPTION
It looks like https://github.com/empress/empress-blog-ghost-helpers/commit/a2d795f0671e8365161c2adc2ce8b1965fd20ea8 didn't include the `route-is` heper that was removed from https://github.com/empress/empress-blog/pull/72

I am assuming it was just an oversight 🤷  who knows 